### PR TITLE
Add Wikidata route to create iNat taxon on Wikidata

### DIFF
--- a/inat2wiki.egg-info/PKG-INFO
+++ b/inat2wiki.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 2.2
+Metadata-Version: 2.4
 Name: inat2wiki
 Version: 0.0.3
 Summary: Collection of functions to move stuff from iNaturalist to Wikidata.
@@ -10,6 +10,7 @@ Requires-Dist: Flask-Session
 Requires-Dist: requests
 Provides-Extra: tests
 Requires-Dist: pytest; extra == "tests"
+Dynamic: license-file
 
 [Repository in construction - sorry for the mess!]
 

--- a/inat2wiki/wikidata.py
+++ b/inat2wiki/wikidata.py
@@ -1,0 +1,85 @@
+import requests
+
+WIKIDATA_API_URL = "https://www.wikidata.org/w/api.php"
+
+def get_inat_taxon_id(scientific_name):
+    """
+    Queries the iNaturalist API to fetch the taxon ID for a given scientific name.
+    """
+    url = "https://api.inaturalist.org/v1/taxa"
+    params = {"q": scientific_name}
+    
+    response = requests.get(url, params=params)
+    data = response.json()
+    
+    if data.get("results"):
+        taxon = data["results"][0]
+        return taxon["id"], taxon["name"]
+    else:
+        return None, None
+
+def get_inat_taxon_id_from_wikidata(qid):
+    """
+    Queries Wikidata to fetch the iNaturalist Taxon ID (P3151) for a given Wikidata entity (QID).
+    
+    :param qid: The Wikidata item ID (e.g., "Q219702" for Monarch butterfly)
+    :return: The iNaturalist Taxon ID as a string, or None if not found.
+    """
+    params = {
+        "action": "wbgetclaims",
+        "entity": qid,
+        "property": "P3151",
+        "format": "json"
+    }
+
+    response = requests.get(WIKIDATA_API_URL, params=params)
+    data = response.json()
+
+    # Check if the property P3151 exists in the claims
+    if "claims" in data and "P3151" in data["claims"]:
+        return data["claims"]["P3151"][0]["mainsnak"]["datavalue"]["value"]
+
+    return None
+
+def get_csrf_token(session):
+    """Fetches a CSRF token required for editing Wikidata."""
+    response = session.get(WIKIDATA_API_URL, params={
+        "action": "query",
+        "meta": "tokens",
+        "type": "csrf",
+        "format": "json"
+    })
+    return response.json().get("query", {}).get("tokens", {}).get("csrftoken")
+
+def add_inat_taxon_id_to_wikidata(qid, taxon_id, oauth_token):
+    """
+    Adds an iNaturalist Taxon ID (P3151) to a Wikidata item (QID).
+
+    :param qid: Wikidata entity ID (e.g., "Q219702" for Monarch butterfly).
+    :param taxon_id: iNaturalist Taxon ID to add (e.g., "47651").
+    :param oauth_token: OAuth token for authentication.
+    :return: Response from Wikidata API.
+    """
+    
+    session = requests.Session()
+    
+    # Authenticate using OAuth
+    session.headers.update({"Authorization": f"Bearer {oauth_token}"})
+
+    # Get CSRF Token
+    csrf_token = get_csrf_token(session)
+    if not csrf_token:
+        return {"error": "Failed to retrieve CSRF token"}
+    
+    # Create the claim
+    response = session.post(WIKIDATA_API_URL, data={
+        "action": "wbcreateclaim",
+        "entity": qid,
+        "property": "P3151",
+        "snaktype": "value",
+        "value": f'"{taxon_id}"',
+        "token": csrf_token,
+        "format": "json"
+    })
+
+    return response.json()

--- a/www/python/src/templates/layout.html
+++ b/www/python/src/templates/layout.html
@@ -53,6 +53,7 @@
         <li class="nav-item"><a class="nav-link" href="/projectlist">Project list</a></li>
         <li class="nav-item"><a class="nav-link" href="/parse">Parse observation</a></li>
         <li class="nav-item"><a class="nav-link" href="/wikistub/pt">Portuguese Wikipedia Stub</a></li>
+        <li class="nav-item"><a class="nav-link" href="/wikidata">Add taxon to Wikidata</a></li>
         <li class="nav-item"><a class="nav-link" href="/about">About</a></li>
       </ul>
     </div>

--- a/www/python/src/templates/wikidata.html
+++ b/www/python/src/templates/wikidata.html
@@ -1,0 +1,49 @@
+{% extends "layout.html" %}
+
+{% block title %}
+User observations
+{% endblock %}
+
+{% block main %}
+
+{% if not qid %}
+
+<h4>Enter the scientific name:</h4>
+<form method="POST">
+  <input name="scientific_name">
+  <input type="submit">
+</form>
+
+{% endif %}
+
+{% if qid %}
+<div class="col-md container">
+  <h3>{{taxon_name}}</h3>
+  <ul>
+    <li> Wikidata page: <a href="https://www.wikidata.org/entity/{{qid}}" target="_blank">{{qid}}</a></li>
+    <li> Taxon ID: <a href="https://www.inaturalist.org/taxa/{{taxon_id}}" target="_blank">{{taxon_id}}</a></li>
+  </ul>
+
+  {% if taxon_id_wikidata == taxon_id %}
+  <p>This taxon ID is already present in Wikidata </p>
+  {% else %}
+  <p>This taxon ID is missing from its Wikidata entity, please confirm below to add this claim to Wikidata</p>
+  <form method="POST" action="/add_taxon_id_to_wikidata">
+    <input type="hidden" name="taxon_id" value="{{taxon_id}}">
+    <input type="hidden" name="qid" value="{{qid}}">
+    <input type="submit" value="Add taxon ID to Wikidata">
+  </form>
+  {% endif %}
+{% endif %}
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul class="flashes">
+      {% for category, message in messages %}
+        <li class="{{ category }}">{{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
+
+{% endblock %}


### PR DESCRIPTION
🚧 Work in progress

This PR adds a new route to handle the case of some taxa being available on iNaturalist but not registered on Wikidata with its [corresponding property](https://www.wikidata.org/wiki/Property:P3151). The general user flow begins by providing the scientific name and then the app checks whether it is already present on Wikidata; if not, an option is provided to add taxon ID to Wikidata. 

Addresses #29 